### PR TITLE
Fixed casing in db creation script.

### DIFF
--- a/create-multiple-postgresql-databases.sh
+++ b/create-multiple-postgresql-databases.sh
@@ -7,9 +7,9 @@ function create_user_and_database() {
 	local database=$1
 	echo "  Creating user and database '$database'"
 	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-	    CREATE USER $database;
-	    CREATE DATABASE $database;
-	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+	    CREATE USER "$database";
+	    CREATE DATABASE "$database";
+	    GRANT ALL PRIVILEGES ON DATABASE "$database" TO "$database";
 EOSQL
 }
 


### PR DESCRIPTION
The `CREATE USER` command in psql is not case sensitive. If you enter a name that includings upper case characters they will be converted to lower case characters. For a user of the multiple databases script, it is hard to find the cause of the error because the output always states that there is not role/database called like the value given in the environment variable.

I added quotes to preserve the casing and avoid confusing results.