### PR TITLE
Add example to many users

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ If you need to use non-standard database names (hyphens, uppercase letters etc),
 
         environment:
             - POSTGRES_MULTIPLE_DATABASES="test-db-1","test-db-2"
+
+
+The `create-multiple-postgresql-full.sh` and `docker-compose.yml` shows an example of how to create both databases and users exclusively to them and assign passwords to them. 
+`user1` will not have access to `db1`,`db2`.

--- a/create-multiple-postgresql-full.sh
+++ b/create-multiple-postgresql-full.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+set -u
+
+containsElement () {
+    IFS=$'\n'
+    local array=$1 val=$2 result=0
+    for var in $array; do
+        if [[ "$var" == "$val" ]]; then
+            result=1
+            break
+        fi
+   done
+   echo "$result"
+}
+
+function create_user_and_database() {
+	local database=$1 user=$2 password=$3
+	local query_users="select rolname from pg_roles;" query_databases="select datname from pg_database;"
+	local roles=$(echo "$query_users" | psql -tA)
+	local databases=$(echo "$query_databases" | psql -Aqt)
+    user_exist=$(containsElement "$roles" "$user")
+    database_exist=$(containsElement "$databases" "$database")
+
+    if [[ "$user_exist" == 1 ]]; then
+        echo "User '$user' exist. Skipping"
+    else
+        echo "Create User '$user'.";
+        psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" \
+            -c "CREATE USER $user WITH PASSWORD '$password'";
+    fi
+    if [[ "$database_exist" == 1 ]]; then
+        echo "Database '$database' exists. Skipping."
+    else
+        echo "Create Database '$database'"
+        psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" \
+            -c "CREATE DATABASE $database;"
+    fi
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" \
+        -c "GRANT ALL PRIVILEGES ON DATABASE $database TO $user;"
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	IFS=', ' read -r -a databases <<< "$POSTGRES_MULTIPLE_DATABASES"
+	IFS=', ' read -r -a users <<< "$POSTGRES_MULTIPLE_USERS"
+	IFS=', ' read -r -a passwords <<< "$POSTGRES_MULTIPLE_PASSWORDS"
+	for index in ${!databases[@]}; do
+        if [[ $index < ${#databases[*]} && $index < ${#users[*]} && $index < ${#passwords[*]} ]] ; then
+              create_user_and_database "${databases[index]//[\'\"\`]/}" "${users[index]//[\'\"\`]/}" "${passwords[index]//[\'\"\`]/}"
+        else
+            echo "DATABASE '${databases[index]}' OR USER '${users[index]}' EMPTY"
+        fi
+	done
+	echo "Multiple databases created"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+services:
+  postgres:
+    image: postgres:alpine
+    container_name: example-postgres
+    environment:
+      - POSTGRES_MULTIPLE_DATABASES="db1","db2","db3"
+      - POSTGRES_MULTIPLE_USERS="user1","user2","user3
+      - POSTGRES_MULTIPLE_PASSWORDS="password1","password2","password3"
+      - POSTGRES_USER=superrole
+      - POSTGRES_PASSWORD=superpassword
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./create-multiple-postgresql-full.sh:/docker-entrypoint-initdb.d/create-multiple-postgresql-full.sh
+    restart: always


### PR DESCRIPTION
Hi.
In your example, there is one significant drawback. If the user or database named "$database" exists, then the script will simply stop and stop working, and the container start will hang. Let's say we did not delete the container, but simply we rebuild through the docker-compose. In my example, this is eliminated, and added it is possible, to register users and passwords explicitly. What makes creating multiple databases more flexible and convenient. People can immediately take an example, and not write, as I did.